### PR TITLE
Change shebang of go.sh

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eux
 


### PR DESCRIPTION
This makes it portable across Unix-like operating systems. For instance it now runs on NixOS as well, which doesn't use `/usr/bin` to store binaries.