### PR TITLE
Check hash in CI and upload artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,16 @@
+name: Build and test
+
+on: [push, pull_request]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.3.1
+    - uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - name: Build
+      run: nix-build -A blynn-compiler
+    - name: Test
+      run: echo "9732a8852bf92b4097f275da4ceba3b718138a5e16190cbef43bbd4be42a27dd result/share/raw" | sha256sum -c

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,3 +14,11 @@ jobs:
       run: nix-build -A blynn-compiler
     - name: Test
       run: echo "9732a8852bf92b4097f275da4ceba3b718138a5e16190cbef43bbd4be42a27dd result/share/raw" | sha256sum -c
+    - run: cp result/bin/vm vm && cp result/share/raw raw
+    - name: Upload vm and raw
+      uses: actions/upload-artifact@v2
+      with:
+        name: build result
+        path: |
+          raw
+          vm

--- a/pkgs/blynn-compiler.nix
+++ b/pkgs/blynn-compiler.nix
@@ -14,7 +14,8 @@ stdenv.mkDerivation {
   '';
 
   installPhase = ''
-    mkdir -p $out/share
+    mkdir -p $out/bin $out/share
     cp bin/raw $out/share
+    cp bin/vm $out/bin
   '';
 }

--- a/pkgs/blynn-compiler.nix
+++ b/pkgs/blynn-compiler.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   '';
 
   installPhase = ''
-    mkdir -p $out
-    cp bin/vm $out/share
+    mkdir -p $out/share
+    cp bin/raw $out/share
   '';
 }

--- a/pkgs/mescc-tools.nix
+++ b/pkgs/mescc-tools.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, gdb, kaem }:
+{ stdenv, fetchgit, kaem }:
 
 stdenv.mkDerivation {
   name = "mescc-tools";


### PR DESCRIPTION
This adds a hash check for `bin/raw` in the CI, so in addition to making sure it can build with M2-Planet, the correctness of the VM is checked as well.