### PR TITLE
blynn-compiler: remove unused dependencies and use mescc-tools-seed

### DIFF
--- a/pkgs/blynn-compiler.nix
+++ b/pkgs/blynn-compiler.nix
@@ -1,9 +1,9 @@
-{ stdenv, lib, help2man, texinfo, mescc-tools, mes-m2, m2-planet }:
+{ stdenvNoCC, lib, mescc-tools-seed }:
 
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   name = "blynn-compiler";
   src = lib.cleanSource ../.;
-  nativeBuildInputs = [ help2man texinfo mescc-tools m2-planet mes-m2 ];
+  nativeBuildInputs = [ mescc-tools-seed ];
 
   postPatch = ''
     patchShebangs go.sh

--- a/pkgs/kaem.nix
+++ b/pkgs/kaem.nix
@@ -1,4 +1,5 @@
 { stdenv, fetchgit }:
+
 stdenv.mkDerivation {
   name = "kaem";
   src = fetchgit {

--- a/pkgs/mes-m2.nix
+++ b/pkgs/mes-m2.nix
@@ -2,6 +2,7 @@
 
 stdenv.mkDerivation rec {
   name = "mes-m2";
+
   src = fetchFromGitHub {
     owner = "oriansj";
     repo = name;

--- a/pkgs/mescc-tools-seed.nix
+++ b/pkgs/mescc-tools-seed.nix
@@ -1,0 +1,19 @@
+{ stdenvNoCC, fetchFromGitHub }:
+
+stdenvNoCC.mkDerivation rec {
+  name = "mescc-tools-seed";
+
+  src = fetchFromGitHub {
+    owner = "oriansj";
+    repo = name;
+    rev = "58e9a4249cde3faead999f94dea5f64c031bb76a";
+    sha256 = "0xib57ygdck8zskhaf4y0msgj24w3xk3slqz4dcfg25pcgg6ymvg";
+    fetchSubmodules = true;
+  };
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ./bin/* $out/bin
+  '';
+}

--- a/pkgs/packages.nix
+++ b/pkgs/packages.nix
@@ -7,4 +7,5 @@ self: super:
   m2-planet = super.callPackage ./m2-planet.nix { };
   mes-m2 = super.callPackage ./mes-m2.nix { };
   mescc-tools = super.callPackage ./mescc-tools.nix { };
+  mescc-tools-seed = super.callPackage ./mescc-tools-seed.nix { };
 }


### PR DESCRIPTION
This shows that it's possible to build `blynn-compiler` with only `mescc-tools-seed`.