### PR TITLE
Fix loading with GHC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@ vm
 raw
 generated/
 bin/
+
+# GHC compilation artifacts
+*.o
+*.dyn*
+*.hi
+*/dist-newstyle/*

--- a/patty.hs
+++ b/patty.hs
@@ -20,7 +20,7 @@ infixl 7 * , / , %;
 infixl 6 + , -;
 infixr 5 ++;
 infixl 4 <*> , <$> , <* , *>;
-infix 4 == , /= , <=;
+infix 4 == , <=;
 infixl 3 && , <|>;
 infixl 2 ||;
 infixl 1 >> , >>=;

--- a/site/wrap1.hs
+++ b/site/wrap1.hs
@@ -19,7 +19,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
-import Prelude ((+), (-), (*), Char, Int, String, succ, Show)
+import Prelude ((+), (-), (*), Char, Int, String, succ, Show, interact)
 import Data.Char (chr, ord)
 import qualified Prelude
 a <= b = if a Prelude.<= b then True else False
@@ -28,4 +28,5 @@ a <= b = if a Prelude.<= b then True else False
 class Eq a where (==) :: a -> a -> Bool
 instance Eq Char where (==) x y = if (x Prelude.== y) then True else False
 instance Eq Int where (==) x y = if (x Prelude.== y) then True else False
-#include "parity.hs"
+#include "../parity.hs"
+main = interact compile

--- a/site/wrap2.hs
+++ b/site/wrap2.hs
@@ -39,4 +39,4 @@ intLE x y = if x Prelude.<= y then True else False
 ioPure = Prelude.pure :: a -> IO a
 ioBind = (Prelude.>>=) :: IO a -> (a -> IO b) -> IO b
 #define ffi foreign import ccall
-#include "patty.hs"
+#include "../patty.hs"

--- a/site/wrap3.hs
+++ b/site/wrap3.hs
@@ -51,4 +51,4 @@ succ :: Int -> Int
 succ = Prelude.succ
 #define ffi foreign import ccall
 #define export --
-#include "marginally.hs"
+#include "../marginally.hs"

--- a/site/wrap4.hs
+++ b/site/wrap4.hs
@@ -96,7 +96,7 @@ ioPure = Prelude.pure :: a -> IO a
 ioBind = (Prelude.>>=) :: IO a -> (a -> IO b) -> IO b
 #define ffi foreign import ccall
 #define export --
-#include "crossly.hs"
+#include "../crossly.hs"
 instance Prelude.Functor Parser where fmap = fmap
 instance Prelude.Applicative Parser where pure = pure ; (<*>) = (<*>)
 instance Prelude.Monad Parser where return = return ; (>>=) = (>>=)


### PR DESCRIPTION
## Motivation
Debugging blynn-compiler through itself can be rather tedious, iterative exploration/development through GHC is much better.

## How to use
Try the following to open a REPL (replace `ghci` with `runhaskell` to interpret), or `ghc -O2` to compile into a binary.

```ShellSession
$ cd site
$ ghci wrap1.hs
$ ghci wrap2.hs
$ ghci wrap4.hs
```

For `wrap3.hs`, you'll need to install the `raw-strings-qq` package via Cabal.

```ShellSession
$ cd site/
$ cabal update
$ cabal install raw-strings-qq
$ cc -o stub.c
$ ghci wrap3.hs stub.o
```

Once in the REPL, reload with `:r`, see type information with `:t <identifier>`, see all the types with `:browse Main`.

Pinging @pder